### PR TITLE
test: await background task completion

### DIFF
--- a/backend/tests/worker/test_tasks.py
+++ b/backend/tests/worker/test_tasks.py
@@ -21,9 +21,8 @@ async def test_create_and_complete():
     async def _ok():
         return 42
 
-    tm.create(_ok, "test_ok")
-    # Task runs immediately with asyncio.create_task, wait briefly
-    await asyncio.sleep(0.1)
+    task = tm.create(_ok, "test_ok")
+    await task
 
     status = tm.get_status()
     assert len(status["running"]) == 0  # completed tasks are removed
@@ -39,8 +38,8 @@ async def test_create_and_fail():
     async def _fail():
         raise RuntimeError("boom")
 
-    tm.create(_fail, "test_fail")
-    await asyncio.sleep(0.1)
+    task = tm.create(_fail, "test_fail")
+    await task
 
     status = tm.get_status()
     failed = [h for h in status["history"] if h["name"].startswith("test_fail")]


### PR DESCRIPTION
## 原因

合并后的 main CI 在高负载下触发了 worker 测试竞态：测试用固定 0.1 秒延时猜测后台任务已结束，但持久化阶段偶尔超过该时间。

## 修复

- 直接等待 BackgroundTaskManager.create() 返回的任务句柄
- 同时修复成功与失败两个同类测试
- 不改变生产代码或运行时行为

## 验证

- Python 语法编译：通过
- git diff --check：通过
- 本机缺少 qdrant-client，完整回归由本 PR GitHub CI 的标准依赖环境执行